### PR TITLE
feat(filecopier): copies idml file from source to destination

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:prod": "node -r ts-node/register/transpile-only -r tsconfig-paths/register ./dist/src/index.js",
     "build": "tsc -p tsconfig.prod.json",
     "test": "jest",
-    "test:watch": "jest npm test --watchAll",
+    "test:watch": "jest npm test --watch",
     "test:no-watch": "jest --watch-false",
     "test:coverage": "jest --coverage",
     "prepare": "husky install",

--- a/src/__testUtils__/FileCopier/testCleanUp.ts
+++ b/src/__testUtils__/FileCopier/testCleanUp.ts
@@ -1,0 +1,21 @@
+import { rmSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+
+const SAMPLE_TEXT_FILE = `${tmpdir()}/sample.txt`;
+const FAKE_IDML_FILE = `${tmpdir()}/fake.idml`;
+const FAKE_FOLDER = `${tmpdir()}/FakeFolder`;
+
+export function testCleanUp(): jest.ProvidesHookCallback {
+  return () => {
+    rmSync(SAMPLE_TEXT_FILE);
+    rmSync(FAKE_FOLDER, { recursive: true });
+  };
+}
+export function testSetUp(): jest.ProvidesHookCallback {
+  return async () => {
+    await writeFile(SAMPLE_TEXT_FILE, 'Sample a text for test.');
+    await writeFile(FAKE_IDML_FILE, 'Fake idml file for test.');
+    await mkdir(FAKE_FOLDER);
+  };
+}

--- a/src/__tests__/FileCopier.spec.ts
+++ b/src/__tests__/FileCopier.spec.ts
@@ -1,0 +1,92 @@
+import { FileCopier } from '@src/core/usecase/FileCopier';
+import { existsSync } from 'fs';
+import { copyFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { testSetUp, testCleanUp } from '../__testUtils__/FileCopier/testCleanUp';
+
+const mockCopy = jest.fn(async (sourcePath: string, destinationPath: string): Promise<void> => {
+  if (!existsSync(sourcePath)) throw new Error('File not found');
+  if (!path.isAbsolute(destinationPath)) throw new Error('Path must be absolute');
+  if (path.extname(sourcePath) !== '.idml') throw new Error('File must be an IDML file');
+  await copyFile(sourcePath, destinationPath);
+});
+
+jest.mock('@src/core/usecase/FileCopier', () => ({
+  FileCopier: jest.fn().mockImplementation(() => ({ copy: mockCopy })),
+}));
+
+beforeAll(testSetUp());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(testCleanUp());
+
+describe('FileCopier', () => {
+  fileCopierInitializerTests();
+  fileCopierErrorsTests();
+  fileCopierImplementationTests();
+});
+
+function fileCopierImplementationTests() {
+  describe('FileCopier implementation', () => {
+    const sourcePath = path.join(`${tmpdir()}/fake.idml`);
+    const destinationPath = path.join(`${tmpdir()}/FakeFolder/fakeIDML.idml`);
+
+    it('should execute copy method and return undefined', async () => {
+      const fileCopier = new FileCopier();
+      const result = fileCopier.copy(sourcePath, destinationPath);
+      await expect(result).resolves.toBe(undefined);
+    });
+
+    it('should copy fake.idml file to FakeFolder', async () => {
+      const isFileExists = existsSync(destinationPath);
+      expect(isFileExists).toBeTruthy();
+    });
+  });
+}
+
+function fileCopierErrorsTests() {
+  describe('FileCopier Errors', () => {
+    const examplePath = path.join(`${tmpdir()}/sample.txt`);
+
+    it('should throw an error if source file path not found', async () => {
+      const fileCopier = new FileCopier();
+      const result = fileCopier.copy('sourcePath', 'destinationPath');
+      await expect(result).rejects.toThrow('File not found');
+    });
+
+    it('should throw an error if destination file path not absolute', async () => {
+      const fileCopier = new FileCopier();
+      const result = fileCopier.copy(examplePath, 'destinationPath');
+      await expect(result).rejects.toThrowError('Path must be absolute');
+    });
+
+    it('should throw an error if source file is not an idml file(.idml extension)', async () => {
+      const fileCopier = new FileCopier();
+      const result = fileCopier.copy(examplePath, examplePath);
+      await expect(result).rejects.toThrowError('File must be an IDML file');
+    });
+  });
+}
+
+function fileCopierInitializerTests() {
+  describe('FileCopier Initialization', () => {
+    it('should be able to call new() on FileCopier', () => {
+      const fileCopier = new FileCopier();
+      expect(fileCopier).toBeTruthy();
+    });
+    it('copy method should have be called once', async () => {
+      const fileCopier = new FileCopier();
+      try {
+        await fileCopier.copy('example', 'example');
+      } catch {
+        // ignore errors
+      } finally {
+        expect(mockCopy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/src/__tests__/ZipExtractor.spec.ts
+++ b/src/__tests__/ZipExtractor.spec.ts
@@ -8,7 +8,7 @@ const { sampleTextFile, exampleZipFile, sourcePath, destinationPath, fakeZipFile
 const delay = promisify(setTimeout);
 
 beforeAll(async () => {
-  setUp({ zipFilePath: exampleZipFile, textFilePath: sampleTextFile });
+  await setUp({ zipFilePath: exampleZipFile, textFilePath: sampleTextFile });
   await delay(250);
 });
 

--- a/src/core/entities/IFileCopier.ts
+++ b/src/core/entities/IFileCopier.ts
@@ -1,0 +1,3 @@
+export interface IFileCopier {
+  copy(sourcePath: string, destinationPath: string): Promise<void>;
+}

--- a/src/core/usecase/FileCopier.ts
+++ b/src/core/usecase/FileCopier.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable class-methods-use-this */
+
+import { existsSync } from 'fs';
+import { copyFile } from 'fs/promises';
+import path from 'path';
+import { IFileCopier } from '../entities/IFileCopier';
+
+export class FileCopier implements IFileCopier {
+  async copy(sourcePath: string, destinationPath: string): Promise<void> {
+    if (!existsSync(sourcePath)) throw new Error('File not found');
+    if (!path.isAbsolute(destinationPath)) throw new Error('Path must be absolute');
+    copyFile(sourcePath, destinationPath);
+  }
+}


### PR DESCRIPTION
feat #12

### FileCopier

-  The class FileCopier implements the interface IFileCopier.
-  The class has a single method, copy, which takes two parameters: sourcePath and destinationPath.
-  The method checks if the sourcePath exists.
-  The method checks if the destinationPath is absolute.
-  The method copies the file.

### Test Cases

**fileCopierImplementationTests**

> -   creating a new FileCopier instance.
> -  calling the copy method and passing in the sourcePath and destinationPath.
> -  asserting that the result of the copy method is undefined.
> -  asserting that the destinationPath exists.

**fileCopierErrorsTests**

> - creates a temporary directory and creates a sample file in it.
> - creates a FileCopier instance.
> - tests if the source file path is not found.
> - tests if the destination file path is not absolute.
> -  tests if the source file is not an idml file(.idml extension).

**fileCopierInitializerTests**

> -  creating a new instance of FileCopier.
> -  calling the copy method on the FileCopier instance.
> -  asserting that the copy method has been called once.



![image](https://user-images.githubusercontent.com/31004510/185184631-b9c3a1cb-eea1-4efe-a137-1db2fa4f756f.png)


