### PR TITLE
Kvamsij/issue25_1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 coverage/
+.vscode/

--- a/src/__tests__/FileRename/FileRename.spec.ts
+++ b/src/__tests__/FileRename/FileRename.spec.ts
@@ -1,21 +1,12 @@
-import { FileRename } from '@src/core/usecase/FileRename';
+import FileRename from '@src/core/usecase/FileRename';
 
 import { existsSync, rmSync } from 'fs';
-import { rename, mkdir, writeFile } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
 
-const mockRename = jest.fn(async (filePath: string): Promise<void> => {
-  if (path.extname(filePath) !== '.idml') throw new Error('Provided file is not an idml file');
-  if (!existsSync(filePath)) throw new Error('File not found');
-  const { dir, name } = path.parse(filePath);
-  const newFilePath = path.join(dir, 'test', `${name}.zip`);
-  await rename(filePath, newFilePath);
-});
-
-jest.mock('@src/core/usecase/FileRename', () => ({
-  FileRename: jest.fn().mockImplementation(() => ({ rename: mockRename })),
-}));
+type FileRenameResults = Promise<{ message: string } | { error: string } | undefined>;
+const SUCCESS_MSG = 'Successfully renamed file';
 
 beforeAll(async () => {
   await mkdir(`${tmpdir()}/FakeFolder/test`, { recursive: true });
@@ -41,20 +32,23 @@ describe('FileRename', () => {
 function FileRenameClassImplementationTest() {
   describe('FileRename Implementation', () => {
     it('should rename filename with .zip as extension', async () => {
-      const fileRename = new FileRename();
-      await fileRename.rename(`${tmpdir()}/FakeFolder/fake.idml`);
+      const fileRename = new FileRename(`${tmpdir()}/FakeFolder/fake.idml`);
+      await fileRename.fsRename();
       const isZipExists = existsSync(`${tmpdir()}/FakeFolder/test/fake.zip`);
       expect(isZipExists).toBeTruthy();
     });
 
     it('should called with given file path', async () => {
-      const fileRename = new FileRename();
+      const sourcePath = path.join(`${tmpdir()}`, 'FakeFolder', 'fake.idml');
+      const fileRename = new FileRename(sourcePath);
       try {
-        await fileRename.rename(`${tmpdir()}/FakeFolder/fake.idml`);
+        await fileRename.fsRename();
       } catch {
         // ignore errors
       } finally {
-        expect(mockRename.mock.calls[0][0]).toEqual(`${tmpdir()}/FakeFolder/fake.idml`);
+        expect(fileRename).toMatchObject({
+          sourcePath,
+        });
       }
     });
   });
@@ -63,34 +57,36 @@ function FileRenameClassImplementationTest() {
 function FileRenameErrorsTest() {
   describe('FileRename Errors', () => {
     it('should throw an error if the filePath does not exists', async () => {
-      const fileRename = new FileRename();
-      const response = fileRename.rename('./example.idml');
-      await expect(response).rejects.toThrowError('File not found');
+      const fileRename = new FileRename('./example.idml');
+      const response = await fileRename.fsRename();
+      expect(response).toMatchObject({ error: 'File Not Found' });
     });
 
     it('should throw an error if the given file extension is not .idml', async () => {
-      const fileRename = new FileRename();
-      const response = fileRename.rename(`${tmpdir()}/FakeFolder/fake.txt`);
-      await expect(response).rejects.toThrowError('Provided file is not an idml file');
+      const fakeTextFile = `${tmpdir()}/FakeFolder/fake.txt`;
+      const fileRename = new FileRename(fakeTextFile);
+      const response = await fileRename.fsRename();
+      expect(response).toMatchObject({ error: 'Provided file is not an idml file' });
     });
   });
 }
 
 function FileRenameClassInitializerTest() {
+  const fileRename = new FileRename('./example');
   describe('FileRename class Initialization', () => {
     it('should be able to call new() on FileRename', () => {
-      const fileRename = new FileRename();
       expect(fileRename).toBeTruthy();
     });
     it('rename method should have been called once', async () => {
-      const fileRename = new FileRename();
-
+      const renameMockMethod = jest
+        .spyOn(fileRename, 'fsRename')
+        .mockImplementation(async (): FileRenameResults => ({ message: SUCCESS_MSG }));
       try {
-        await fileRename.rename('./example.txt');
+        await fileRename.fsRename();
       } catch {
         // ignore errors
       } finally {
-        expect(mockRename).toHaveBeenCalledTimes(1);
+        expect(renameMockMethod).toHaveBeenCalledTimes(1);
       }
     });
   });

--- a/src/core/entities/IFileRename.ts
+++ b/src/core/entities/IFileRename.ts
@@ -1,0 +1,5 @@
+type FileRenameResults = Promise<{ message: string } | { error: string } | undefined>;
+
+export interface IFileRename {
+  fsRename(): FileRenameResults;
+}

--- a/src/core/usecase/FileRename.ts
+++ b/src/core/usecase/FileRename.ts
@@ -1,14 +1,39 @@
-import { existsSync } from 'fs';
-import { rename } from 'fs/promises';
-import path from 'path';
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-default-export */
 
-export class FileRename {
-  // eslint-disable-next-line class-methods-use-this
-  async rename(filePath: string): Promise<void> {
-    if (path.extname(filePath) !== '.idml') throw new Error('Provided file is not an idml file');
-    if (!existsSync(filePath)) throw new Error('File not found');
-    const { dir, name } = path.parse(filePath);
-    const newFilePath = path.join(dir, 'test', `${name}.zip`);
-    await rename(filePath, newFilePath);
+import path from 'path';
+import { rename } from 'fs/promises';
+import { IFileRename } from '../entities/IFileRename';
+
+type FileRenameResults = Promise<{ message: string } | { error: string } | undefined>;
+
+const FILE_EXTENSION = '.idml';
+const SUCCESS_MSG = { message: 'Successfully rename file' };
+
+const ERRORS = {
+  FILE_NOT_FOUND: { error: 'File Not Found' },
+  NOT_IDML_FILE: { error: 'Provided file is not an idml file' },
+};
+
+export default class FileRename implements IFileRename {
+  private newFilePath: string;
+
+  private hasExtensionIDML: boolean;
+
+  constructor(private sourcePath: string) {
+    const { dir, name } = path.parse(this.sourcePath);
+    this.newFilePath = path.join(dir, 'test', `${name}.zip`);
+    this.hasExtensionIDML = path.extname(this.sourcePath) === FILE_EXTENSION;
+  }
+
+  async fsRename(): FileRenameResults {
+    if (!this.hasExtensionIDML) return ERRORS.NOT_IDML_FILE;
+    try {
+      await rename(this.sourcePath, this.newFilePath);
+      return SUCCESS_MSG;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      return ERRORS.FILE_NOT_FOUND;
+    }
   }
 }


### PR DESCRIPTION
- refactor FileRename.spec.ts, FileRename.ts and IFileRename.ts for error handling.

- Instead of just throwing new error now returns a Promise with message as string or error as string.

re #25