### PR TITLE
Kvamsij/issue34

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   coverageDirectory: 'coverage',
-  collectCoverageFrom: ['src/**/*.{js,ts}'],
+  collectCoverageFrom: ['src/**/*.{js,ts}', '!src/__testUtils__/**/*.{js,ts}'],
   coverageThreshold: {
     global: {
       branches: 0,

--- a/src/__testUtils__/ErrorHandler/ErrorHandlerTestCleanUp.ts
+++ b/src/__testUtils__/ErrorHandler/ErrorHandlerTestCleanUp.ts
@@ -1,0 +1,8 @@
+import { existsSync } from 'fs';
+import { rm } from 'fs/promises';
+
+export function ErrorHandlerTestCleanUp(testFolder: string): jest.ProvidesHookCallback {
+  return async () => {
+    if (existsSync(testFolder)) await rm(testFolder, { recursive: true });
+  };
+}

--- a/src/__testUtils__/ErrorHandler/ErrorHandlerTestSetUp.ts
+++ b/src/__testUtils__/ErrorHandler/ErrorHandlerTestSetUp.ts
@@ -1,0 +1,19 @@
+import { FilePaths } from '@src/core/usecase/ErrorHandler';
+import { existsSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
+
+export function ErrorHandlerTestSetUp(testFolder: string, filePaths: FilePaths): jest.ProvidesHookCallback {
+  return async () => {
+    const { zipFilePath, idmlFilePath, extractedFolderPath } = filePaths;
+    const foldersToCreate = [testFolder, extractedFolderPath];
+    const filesToCreate = [zipFilePath, idmlFilePath];
+
+    foldersToCreate.forEach(async (folder) => {
+      if (!existsSync(folder)) await mkdir(folder);
+    });
+
+    filesToCreate.forEach(async (filePath) => {
+      if (!existsSync(filePath)) await writeFile(filePath, 'Sample fake file to test');
+    });
+  };
+}

--- a/src/__testUtils__/ErrorHandler/filePaths.ts
+++ b/src/__testUtils__/ErrorHandler/filePaths.ts
@@ -1,0 +1,10 @@
+import { FilePaths } from '@src/core/usecase/ErrorHandler';
+import { tmpdir } from 'os';
+import path from 'path';
+
+export const testFolder = path.join(tmpdir(), 'ErrorHandlerTest');
+export const filePaths: FilePaths = {
+  zipFilePath: path.join(testFolder, 'fakeZip.zip'),
+  idmlFilePath: path.join(testFolder, 'fakeIdml.idml'),
+  extractedFolderPath: path.join(testFolder, 'FakeFolder'),
+};

--- a/src/__tests__/ErrorHandler/ErrorHandler.spec.ts
+++ b/src/__tests__/ErrorHandler/ErrorHandler.spec.ts
@@ -1,0 +1,62 @@
+import { ErrorHandler } from '@src/core/usecase/ErrorHandler';
+import { ErrorHandlerTestCleanUp } from '@src/__testUtils__/ErrorHandler/ErrorHandlerTestCleanUp';
+import { ErrorHandlerTestSetUp } from '@src/__testUtils__/ErrorHandler/ErrorHandlerTestSetUp';
+import { filePaths, testFolder } from '@src/__testUtils__/ErrorHandler/filePaths';
+import { existsSync } from 'fs';
+
+beforeAll(ErrorHandlerTestSetUp(testFolder, filePaths));
+afterAll(ErrorHandlerTestCleanUp(testFolder));
+afterEach(() => jest.clearAllMocks());
+
+describe('ErrorHandler', () => {
+  ErrorHandlerInstantiationTest();
+  ErrorHandlerImplementationTest();
+  ErrorHandlerErrorChecksTest();
+});
+
+function ErrorHandlerInstantiationTest() {
+  describe('ErrorHandler: Instantiation', () => {
+    const errorHandler = new ErrorHandler(filePaths);
+    it('should be able to create new(filePaths) on class ErrorHandler', () => {
+      expect(errorHandler).toBeTruthy();
+    });
+    it('should be called with filePaths', () => {
+      expect(errorHandler).toMatchObject({ filePaths });
+    });
+  });
+}
+
+function ErrorHandlerImplementationTest() {
+  describe('ErrorHandler: Implementation', () => {
+    const errorHandler = new ErrorHandler(filePaths);
+    const spyOnHandleMock = jest.spyOn(errorHandler, 'handle');
+
+    it('should call handler() once', () => {
+      errorHandler.handle();
+      expect(spyOnHandleMock).toBeCalledTimes(1);
+    });
+
+    it('should delete zipFile if exists', () => {
+      const isZipFileExists = existsSync(filePaths.zipFilePath);
+      expect(isZipFileExists).toBeFalsy();
+    });
+    it('should delete idmlFile if exists', () => {
+      const isIdmlFileExists = existsSync(filePaths.idmlFilePath);
+      expect(isIdmlFileExists).toBeFalsy();
+    });
+    it('should delete extractedFolder if exists', () => {
+      const isFolderExists = existsSync(filePaths.extractedFolderPath);
+      expect(isFolderExists).toBeFalsy();
+    });
+  });
+}
+
+function ErrorHandlerErrorChecksTest() {
+  describe('ErrorHandler: Error Checks', () => {
+    const errorHandler = new ErrorHandler({ zipFilePath: '', extractedFolderPath: '', idmlFilePath: '' });
+    errorHandler.handle();
+    it('should not throw any errors', () => {
+      expect(errorHandler.handle()).toBe(undefined);
+    });
+  });
+}

--- a/src/core/entities/IErrorHandler.ts
+++ b/src/core/entities/IErrorHandler.ts
@@ -1,0 +1,3 @@
+export interface IErrorHandler {
+  handle(): void;
+}

--- a/src/core/usecase/ErrorHandler.ts
+++ b/src/core/usecase/ErrorHandler.ts
@@ -1,0 +1,23 @@
+import { existsSync, rmSync } from 'fs';
+
+export type FilePaths = {
+  zipFilePath: string;
+  idmlFilePath: string;
+  extractedFolderPath: string;
+};
+
+export class ErrorHandler {
+  private filePaths: FilePaths;
+
+  constructor(filePaths: FilePaths) {
+    this.filePaths = filePaths;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  handle() {
+    const { zipFilePath, idmlFilePath, extractedFolderPath } = this.filePaths;
+    [zipFilePath, idmlFilePath, extractedFolderPath].forEach((filePath) => {
+      if (existsSync(filePath)) rmSync(filePath, { recursive: true });
+    });
+  }
+}

--- a/src/core/usecase/ErrorHandler.ts
+++ b/src/core/usecase/ErrorHandler.ts
@@ -1,4 +1,5 @@
 import { existsSync, rmSync } from 'fs';
+import { IErrorHandler } from '../entities/IErrorHandler';
 
 export type FilePaths = {
   zipFilePath: string;
@@ -6,7 +7,7 @@ export type FilePaths = {
   extractedFolderPath: string;
 };
 
-export class ErrorHandler {
+export class ErrorHandler implements IErrorHandler {
   private filePaths: FilePaths;
 
   constructor(filePaths: FilePaths) {
@@ -14,7 +15,7 @@ export class ErrorHandler {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  handle() {
+  handle(): void {
     const { zipFilePath, idmlFilePath, extractedFolderPath } = this.filePaths;
     [zipFilePath, idmlFilePath, extractedFolderPath].forEach((filePath) => {
       if (existsSync(filePath)) rmSync(filePath, { recursive: true });


### PR DESCRIPTION
fix #34 

### ErrorHandler Test Suit
**ErrorHandlerImplementationTest**

> - Import the ErrorHandler class from the error-handler.ts file.
> - Create an instance of the ErrorHandler class.
> - Create a mock function that will be used to test the ErrorHandler class.
> - Call the handle() method of the ErrorHandler class.
> - Verify that the handle() method of the ErrorHandler class is called once.
> - Verify that the zipFile is deleted if it exists.
> - Verify that the idmlFile is deleted if it exists.
> - Verify that the extractedFolder is deleted if it exists.

**ErrorHandlerInstantiationTest**

> - creating a new instance of the ErrorHandler class.
> - checking that the instance is truthy.
> - checking that the instance is an instance of ErrorHandler.
> - checking that the instance has the filePaths property.
> - checking that the instance has the filePaths property and that it matches the filePaths we passed in.

**ErrorHandlerErrorChecksTest**

> - The ErrorHandler class is created with the required parameters.
> - The handle() method is called.
> - The handle() method is expected to return undefined.
> - The handle() method is expected to not throw any errors.

### ErrorHandler Class

> - The constructor takes in the file paths and stores them in the filePaths property.
> - The handle() method is called when an error occurs. It removes the files that were created during the import process.

![image](https://user-images.githubusercontent.com/31004510/185804599-d18999ef-60ed-4323-ac33-9f6c6d65d21e.png)
